### PR TITLE
Fix fatal errors with new versions of TweakScale

### DIFF
--- a/GameData/BladeTweaks/MakingHistory-TweakScale.cfg
+++ b/GameData/BladeTweaks/MakingHistory-TweakScale.cfg
@@ -1,21 +1,3 @@
-// Part missing from Aero.cfg in TweakScale MakingHistory folder
-@PART[Size_1_5_Cone] // Protective Rocket Nosecone Mk5A
-{
-	%MODULE[TweakScale]
-	{
-		type = stack
-		defaultScale = 1.875
-	}
-}
-// Part missing from Aero.cfg in TweakScale MakingHistory folder
-@PART[rocketNoseConeSize4] // Protective Nose Cone Mk16A
-{
-	%MODULE[TweakScale]
-	{
-		type = stack
-		defaultScale = 5.0
-	}
-}
 // Removing TweakScale from engine plates as it does not work currently due to https://github.com/net-lisias-ksp/TweakScale/issues/13
 @PART[EnginePlate*]:AFTER[TweakScale]
 {

--- a/GameData/BladeTweaks/Squad-TweakScale.cfg
+++ b/GameData/BladeTweaks/Squad-TweakScale.cfg
@@ -38,44 +38,6 @@
 	}
 }
 
-// Size2 Solid Boosters
-@PART[Clydesdale]:FOR[TweakScale] // Clydesdale (solidBoosterS2-33) for KSP >= 1.8
-{
-    #@TWEAKSCALEBEHAVIOR[SRB]/MODULE[TweakScale] { }
-    %MODULE[TweakScale]
-    {
-        type = stack
-        defaultScale = 2.5
-    }
-}
-@PART[Thoroughbred]:FOR[TweakScale] // Thoroughbred (solidBoosterS2-17) for KSP >= 1.8
-{
-    #@TWEAKSCALEBEHAVIOR[SRB]/MODULE[TweakScale] { }
-    %MODULE[TweakScale]
-    {
-        type = stack
-        defaultScale = 2.5
-    }
-}
-@PART[Shrimp]:FOR[TweakScale] // Shrimp (SolidBoosterF3S0) for KSP >= 1.8
-{
-    #@TWEAKSCALEBEHAVIOR[SRB]/MODULE[TweakScale] { }
-    %MODULE[TweakScale]
-    {
-        type = stack
-        defaultScale = 0.625
-    }
-}
-@PART[Mite]:FOR[TweakScale] // Mite (SolidBoosterFM1) for KSP >= 1.8
-{
-    #@TWEAKSCALEBEHAVIOR[SRB]/MODULE[TweakScale] { }
-    %MODULE[TweakScale]
-    {
-        type = stack
-        defaultScale = 0.625
-    }
-}
-
 // Experiment Storage Unit
 @PART[ScienceBox]:FINAL //  Experiment Storage Unit for KSP >= 1.5
 {


### PR DESCRIPTION
Fixes a fatal error on startup when using new versions of TweakScale.

```
[LOG 09:21:04.371] [TweakScale] ERROR: FATAL Part Thoroughbred (S2-17 "Thoroughbred" Solid Fuel Booster) has a fatal problem due having duplicated properties - see issue https://github.com/net-lisias-ksp/TweakScale/issues/34. at error:0
[LOG 09:21:04.371] [TweakScale] ERROR: FATAL Part Clydesdale (S2-33 "Clydesdale" Solid Fuel Booster) has a fatal problem due having duplicated properties - see issue https://github.com/net-lisias-ksp/TweakScale/issues/34. at error:0
[LOG 09:21:04.372] [TweakScale] ERROR: FATAL Part Shrimp (F3S0 "Shrimp" Solid Fuel Booster) has a fatal problem due having duplicated properties - see issue https://github.com/net-lisias-ksp/TweakScale/issues/34. at error:0
[LOG 09:21:04.372] [TweakScale] ERROR: FATAL Part Mite (FM1 "Mite" Solid Fuel Booster) has a fatal problem due having duplicated properties - see issue https://github.com/net-lisias-ksp/TweakScale/issues/34. at error:0
[LOG 09:21:04.389] [TweakScale] ERROR: FATAL Part rocketNoseConeSize4 (Protective Rocket Nose Cone Mk16A) has a fatal problem due having duplicated properties - see issue https://github.com/net-lisias-ksp/TweakScale/issues/34. at error:0
[LOG 09:21:04.389] [TweakScale] ERROR: FATAL Part Size.1.5.Cone (Protective Rocket Nosecone Mk5A) has a fatal problem due having duplicated properties - see issue https://github.com/net-lisias-ksp/TweakScale/issues/34. at error:0
```

See here for more information: https://github.com/TweakScale/TweakScale/issues/34#issuecomment-782958431